### PR TITLE
Auto install bom

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Mix task available for that project only:
 ```elixir
 def deps do
   [
-    {:sbom, "~> 0.5.1", only: :dev, runtime: false}
+    {:sbom, git: "https://github.com/sigu/sbom.git", branch: "auto-install-bom", only: :dev, runtime: false}
   ]
 end
 ```
@@ -40,6 +40,18 @@ run `mix help sbom.cyclonedx`.
 
 ## NPM packages and other dependencies
 
+If you are running a phoenix project, you can generate your phoenix dependencies sbom file too by running the command `mix sbom.phx`. You need to add the following to your dev config
+
+``` elixir
+config :sbom,
+  cyclone_cli: "0.24.0",
+  cyclone_npm: "3.10.4",
+  cd: Path.expand("../assets", __DIR__),
+  bom_location: Path.expand("../priv/static/.well-known/sbom", __DIR__)
+```
+
+### Automated generating of sbom
+
 This tool only considers Hex, GitHub and BitBucket dependencies managed through
 Mix. To build a comprehensive SBoM of a deployment, including NPM and/or
 operating system packages, it may be necessary to merge multiple CycloneDX files
@@ -49,3 +61,10 @@ The [@cyclonedx/bom](https://www.npmjs.com/package/@cyclonedx/bom) tool on NPM
 can not only generate an SBoM for your JavaScript assets, but it can also merge
 in the output of the 'sbom.cyclonedx' Mix task and other scanners, through the
 '-a' option, producing a single CycloneDX XML file.
+
+
+## To do
+
+- [ ] enable passing of arguments to the cli
+- [ ] configurable output filenames
+- [ ] generate templates and serve the sbom on phoenix projects

--- a/lib/mix/tasks/sbom.convert.ex
+++ b/lib/mix/tasks/sbom.convert.ex
@@ -1,0 +1,26 @@
+defmodule Mix.Tasks.Sbom.Convert do
+  @shortdoc "Convert bom file to different formats"
+
+  use Mix.Task
+
+  alias Sbom.Cli
+
+  @default_path "bom.xml"
+
+  @moduledoc """
+  Generates a Software Bill-of-Materials (SBoM) in CycloneDX format.
+
+  ## Options
+    * `--input` (`-i`): the full path to the SBoM input file (default:
+      #{@default_path})
+  """
+
+  @doc false
+  @impl Mix.Task
+  def run(all_args) do
+    {opts, _args} = OptionParser.parse!( all_args, aliases: [i: :input], strict: [ input: :string ])
+    input_path = opts[:input] || @default_path
+    Cli.convert(input_path)
+  end
+
+end

--- a/lib/mix/tasks/sbom.cyclonedx.ex
+++ b/lib/mix/tasks/sbom.cyclonedx.ex
@@ -85,9 +85,7 @@ defmodule Mix.Tasks.Sbom.Cyclonedx do
       shell = Mix.shell()
 
       shell.error(
-        "invalid cyclonedx schema version, available versions are #{
-          schema_versions |> Enum.join(", ")
-        }"
+        "invalid cyclonedx schema version, available versions are #{schema_versions |> Enum.join(", ")}"
       )
 
       Mix.raise("Give correct cyclonedx schema version to continue.")

--- a/lib/mix/tasks/sbom.install.ex
+++ b/lib/mix/tasks/sbom.install.ex
@@ -1,0 +1,9 @@
+defmodule Mix.Tasks.Sbom.Install do
+  @shortdoc "Install Elixir Sbom"
+
+  use Mix.Task
+
+  def run(_args) do
+    Sbom.Cli.install()
+  end
+end

--- a/lib/mix/tasks/sbom.phx.ex
+++ b/lib/mix/tasks/sbom.phx.ex
@@ -1,28 +1,20 @@
 defmodule Mix.Tasks.Sbom.Phx do
-  @shortdoc "Generate sbom for node packages"
+  @moduledoc "Genrates bom files for phoenix projects"
+  @shortdoc "Generate sbom for phoenix projects"
 
   use Mix.Task
   require Logger
 
-  def run(_args) do
+  @impl Mix.Task
+  def run(args) do
     Sbom.Cli.install()
-    path = Application.get_env(:sbom, :cd)
-    Logger.debug("generating node modules bom")
 
-    res =
-      System.cmd(
-        path <> "/node_modules/@cyclonedx/bom/bin/make-bom.js",
-        ["--output=../bom_phx.xml"],
-        cd: path
-      )
-
-    case res do
-      {_, 0} -> Logger.debug("Successfully generated bom file")
-      _ -> Logger.error("Failed to generate node modules bom file")
+    unless File.exists?("bom.xml") do
+      Mix.Task.run("sbom.cyclonedx", args)
     end
 
-    Logger.debug("Merging the two files")
-    Sbom.Cli.merge("bom_phx.xml", "bom.xml")
-    Sbom.Cli.convert("bom_merged.xml")
+    Sbom.Cli.Phx.bom()
+    |> Sbom.Cli.merge("bom.xml")
+    |> Sbom.Cli.convert()
   end
 end

--- a/lib/mix/tasks/sbom.phx.ex
+++ b/lib/mix/tasks/sbom.phx.ex
@@ -1,0 +1,28 @@
+defmodule Mix.Tasks.Sbom.Phx do
+  @shortdoc "Generate sbom for node packages"
+
+  use Mix.Task
+  require Logger
+
+  def run(_args) do
+    Sbom.Cli.install()
+    path = Application.get_env(:sbom, :cd)
+    Logger.debug("generating node modules bom")
+
+    res =
+      System.cmd(
+        path <> "/node_modules/@cyclonedx/bom/bin/make-bom.js",
+        ["--output=../bom_phx.xml"],
+        cd: path
+      )
+
+    case res do
+      {_, 0} -> Logger.debug("Successfully generated bom file")
+      _ -> Logger.error("Failed to generate node modules bom file")
+    end
+
+    Logger.debug("Merging the two files")
+    Sbom.Cli.merge("bom_phx.xml", "bom.xml")
+    Sbom.Cli.convert("bom_merged.xml")
+  end
+end

--- a/lib/mix/tasks/sbom.phx.ex
+++ b/lib/mix/tasks/sbom.phx.ex
@@ -7,14 +7,43 @@ defmodule Mix.Tasks.Sbom.Phx do
 
   @impl Mix.Task
   def run(args) do
-    Sbom.Cli.install()
+    unless node_version(),
+      do: Mix.raise("Nodejs not installed on the system, to continue install nodejs")
 
-    unless File.exists?("bom.xml") do
-      Mix.Task.run("sbom.cyclonedx", args)
+    unless Application.get_env(:sbom, :cd) do
+      raise ArgumentError, """
+      Before you run this, you need to setup configurations in config/dev.exs such as:
+      config :sbom,
+        cyclone_cli: "0.24.0",
+        cyclone_npm: "3.10.4",
+        cd: Path.expand("../assets", __DIR__),
+        bom_location: Path.expand("../priv/static/.well-known/sbom", __DIR__)
+      """
     end
 
-    Sbom.Cli.Phx.bom()
-    |> Sbom.Cli.merge("bom.xml")
-    |> Sbom.Cli.convert()
+    Sbom.Cli.install()
+
+    Mix.Task.run("sbom.cyclonedx", args)
+
+    file =
+      if is_phx?() do
+        Sbom.Cli.Phx.install()
+        Sbom.Cli.Phx.bom() |> Sbom.Cli.merge("bom.xml")
+      else
+        "bom.xml"
+      end
+
+    Sbom.Cli.convert(file)
+  end
+
+  def node_version do
+    case System.cmd("node", ["--version"]) do
+      {v, 0} -> String.trim(v)
+      _ -> nil
+    end
+  end
+
+  def is_phx? do
+    File.exists?(Application.get_env(:sbom, :cd) <> "/package.json")
   end
 end

--- a/lib/sbom/cli.ex
+++ b/lib/sbom/cli.ex
@@ -1,0 +1,206 @@
+defmodule Sbom.Cli do
+  require Logger
+
+  def install do
+    version = Application.get_env(:sbom, :cyclone_cli) || "0.24.0"
+
+    case bin_version() do
+      {:ok, ^version} ->
+        Logger.debug("Skipping, already installed version #{version}")
+
+      _ ->
+        name = "cyclonedx-#{target()}"
+        url = "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v#{version}/#{name}"
+        bin_path = bin_path()
+        binary = fetch_body!(url)
+        File.mkdir_p!(Path.dirname(bin_path))
+        File.write!(bin_path, binary, [:binary])
+        File.chmod(bin_path, 0o755)
+    end
+
+    cd = Application.get_env(:sbom, :cd) || Path.expand("../assets", __DIR__)
+    if File.exists?( cd <> "/package.json") do
+      Logger.debug("Found a package.json file")
+      install_npm()
+    end
+  end
+
+  def install_npm do
+    Logger.debug("Installing npm bom generator")
+
+    case System.cmd("npm", ["install", "-D ", "@cyclonedx/bom"],
+           cd: Application.get_env(:sbom, :cd)
+         ) do
+      {_, 0} -> Logger.debug("Successfully installed cyclonedx for npm packages")
+      {error, _} -> Logger.error("There was an error during installation", error: error)
+    end
+  end
+
+  def bin_version do
+    with true <- File.exists?(bin_path()),
+         {result, 0} <- System.cmd(bin_path(), ["--version"]) do
+      {:ok, result |> String.trim()}
+    else
+      _ -> :error
+    end
+  end
+
+  @doc """
+  Returns the path to the executable.
+  The executable may not be available if it was not yet installed.
+  """
+  def bin_path do
+    name = "cyclonedx-cli-#{target()}"
+
+    Application.get_env(:tailwind, :path) ||
+      if Code.ensure_loaded?(Mix.Project) do
+        Path.join(Path.dirname(Mix.Project.build_path()), name)
+      else
+        Path.expand("_build/#{name}")
+      end
+  end
+
+  # Available targets:
+  # cyclonedx-linux-arm
+  # cyclonedx-linux-arm64
+  # cyclonedx-linux-x64
+  # cyclonedx-osx-arm64
+  # cyclonedx-osx-x64
+  # cyclonedx-win-arm.exe
+  # cyclonedx-win-arm64.exe
+  # cyclonedx-win-x64.exe
+  # cyclonedx-win-x86.exe
+  defp target do
+    arch_str = :erlang.system_info(:system_architecture)
+    [arch | _] = arch_str |> List.to_string() |> String.split("-")
+
+    case {:os.type(), arch, :erlang.system_info(:wordsize) * 8} do
+      {{:win32, _}, _arch, 64} ->
+        "windows-x64.exe"
+
+      {{:unix, :darwin}, arch, 64} when arch in ~w(arm aarch64) ->
+        "osx-arm64"
+
+      {{:unix, :darwin}, "x86_64", 64} ->
+        "osx-x64"
+
+      {{:unix, :linux}, "aarch64", 64} ->
+        "linux-arm64"
+
+      {{:unix, _osname}, arch, 64} when arch in ~w(x86_64 amd64) ->
+        "linux-x64"
+
+      {_os, _arch, _wordsize} ->
+        raise "cyclondedx cli is not available for architecture: #{arch_str}"
+    end
+  end
+
+  defp fetch_body!(url) do
+    url = String.to_charlist(url)
+    Logger.debug("Downloading cyclonedx cli from #{url}")
+
+    {:ok, _} = Application.ensure_all_started(:inets)
+    {:ok, _} = Application.ensure_all_started(:ssl)
+
+    if proxy = System.get_env("HTTP_PROXY") || System.get_env("http_proxy") do
+      Logger.debug("Using HTTP_PROXY: #{proxy}")
+      %{host: host, port: port} = URI.parse(proxy)
+      :httpc.set_options([{:proxy, {{String.to_charlist(host), port}, []}}])
+    end
+
+    if proxy = System.get_env("HTTPS_PROXY") || System.get_env("https_proxy") do
+      Logger.debug("Using HTTPS_PROXY: #{proxy}")
+      %{host: host, port: port} = URI.parse(proxy)
+      :httpc.set_options([{:https_proxy, {{String.to_charlist(host), port}, []}}])
+    end
+
+    # https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/inets
+    cacertfile = CAStore.file_path() |> String.to_charlist()
+
+    http_options = [
+      ssl: [
+        verify: :verify_peer,
+        cacertfile: cacertfile,
+        depth: 2,
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
+      ]
+    ]
+
+    options = [body_format: :binary]
+
+    case :httpc.request(:get, {url, []}, http_options, options) do
+      {:ok, {{_, 200, _}, _headers, body}} ->
+        body
+
+      other ->
+        raise "couldn't fetch #{url}: #{inspect(other)}"
+    end
+  end
+
+  def merge(file1, file2) do
+    input_files = file1 <> " " <> file2
+    output_filename = 'bom_merged.xml'
+
+    cmd =
+      String.to_charlist(bin_path()) ++
+        ' merge --input-files=' ++
+        String.to_charlist(input_files) ++
+        ' --output-file=' ++
+        output_filename ++
+        ' --name=' ++
+        to_charlist(name()) ++
+        ' --version=' ++ to_charlist(version())
+
+    cmd |> :os.cmd() |> Logger.debug()
+  end
+
+  def convert(
+        input_file \\ "bom.xml",
+        version \\ "1_3",
+        output_formats \\ ["xml", "json", "spdxjson"]
+      ) do
+    for output <- output_formats do
+      {output_file, output_format} =
+        case output do
+          "xml" -> {filename() <> "-cyclonedx-sbom.1.0.0.xml", "xml"}
+          "json" -> {filename() <> "-cyclonedx-sbom.1.0.0.json", "json"}
+          "spdxjson" -> {filename() <> "-spdx-sbom.1.0.0.spdx", "spdxjson"}
+        end
+
+      bin_path()
+      |> System.cmd([
+        "convert",
+        "--input-file=" <> input_file,
+        "--output-file=" <> output_directory() <> "/" <> output_file,
+        "--output-version=v" <> version,
+        "--output-format=" <> output_format
+      ])
+    end
+  end
+
+  defp filename do
+    to_string(name()) <> "." <> to_string(version())
+  end
+
+  defp name do
+    config()[:app]
+  end
+
+  defp version do
+    config()[:version]
+  end
+
+  defp config do
+    Mix.Project.config()
+  end
+
+  defp output_directory do
+    path = Application.get_env(:sbom, :bom_location) || "priv/static/.well-known/sbom"
+    unless File.exists?(path) do
+      File.mkdir!(path)
+    end
+    path
+  end
+end

--- a/lib/sbom/cli.ex
+++ b/lib/sbom/cli.ex
@@ -1,6 +1,5 @@
 defmodule Sbom.Cli do
   require Logger
-  alias Sbom.Cli.Phx
 
   def install do
     version = Application.get_env(:sbom, :cyclone_cli) || "0.24.0"
@@ -17,11 +16,6 @@ defmodule Sbom.Cli do
         File.mkdir_p!(Path.dirname(bin_path))
         File.write!(bin_path, binary, [:binary])
         File.chmod(bin_path, 0o755)
-    end
-
-    if File.exists?(Application.get_env(:sbom, :cd) <> "/package.json") do
-      Logger.debug("Found a package.json file, assuming a node project")
-      Phx.install()
     end
   end
 
@@ -174,7 +168,21 @@ defmodule Sbom.Cli do
         "--output-version=v" <> version,
         "--output-format=" <> output_format
       ])
+
+      output_directory() <> "/" <> output_file
     end
+    |> print_filenames()
+  end
+
+  defp print_filenames(filenames) do
+    Logger.debug("Created the following files ")
+
+    Enum.with_index(filenames, fn name, index ->
+      """
+      #{index + 1}. #{Path.relative_to(name, File.cwd!())}
+      """
+    end)
+    |> Mix.shell().info()
   end
 
   defp filename do

--- a/lib/sbom/cli/phx.ex
+++ b/lib/sbom/cli/phx.ex
@@ -1,0 +1,61 @@
+defmodule Sbom.Cli.Phx do
+  require Logger
+
+  def install do
+    version = Application.get_env(:sbom, :cyclone_npm) || "3.10.4"
+
+    case bin_version() do
+      {:ok, ^version} -> Logger.debug("Already installed version " <> version)
+      _ -> do_install(version)
+    end
+  end
+
+  defp do_install(version) do
+    Logger.debug("Installing npm bom generator version " <> version)
+
+    case System.cmd("npm", ["install", "-D ", "@cyclonedx/bom@" <> version],
+           cd: Application.get_env(:sbom, :cd)
+         ) do
+      {_, 0} ->
+        Logger.debug("Successfully installed cyclonedx version #{version} for npm packages")
+
+      {error, _} ->
+        Logger.error("There was an error during installation", error: error)
+    end
+  end
+
+  def bin_version do
+    with true <- File.exists?(bin_path()),
+         {result, 0} <- System.cmd(bin_path(), ["--version"]) do
+      {:ok, result |> String.trim()}
+    else
+      _ -> :error
+    end
+  end
+
+  def bin_path do
+    Application.get_env(:sbom, :cd) <> "/node_modules/@cyclonedx/bom/bin/make-bom.js"
+  end
+
+  def bom do
+    path = Application.get_env(:sbom, :cd)
+    Logger.debug("generating node modules bom")
+
+    res =
+      System.cmd(
+        path <> "/node_modules/@cyclonedx/bom/bin/make-bom.js",
+        ["--output=../bom_phx.xml"],
+        cd: path
+      )
+
+    case res do
+      {_, 0} ->
+        Logger.debug("Successfully generated bom file")
+        "bom_phx.xml"
+
+      _ ->
+        Logger.error("Failed to generate node modules bom file")
+        :error
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule SBoM.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:castore, ">= 0.0.0"},
       {:ex_doc, "~> 0.21", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,8 @@
 %{
-  "earmark": {:hex, :earmark, "1.4.2", "3aa0bd23bc4c61cf2f1e5d752d1bb470560a6f8539974f767a38923bb20e1d7f", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
+  "castore": {:hex, :castore, "0.1.17", "ba672681de4e51ed8ec1f74ed624d104c0db72742ea1a5e74edbc770c815182f", [:mix], [], "hexpm", "d9844227ed52d26e7519224525cb6868650c272d4a3d327ce3ca5570c12163f9"},
+  "earmark": {:hex, :earmark, "1.4.2", "3aa0bd23bc4c61cf2f1e5d752d1bb470560a6f8539974f767a38923bb20e1d7f", [:mix], [], "hexpm", "5e8806285d8a3a8999bd38e4a73c58d28534c856bc38c44818e5ba85bbda16fb"},
+  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f1155337ae17ff7a1255217b4c1ceefcd1860b7ceb1a1874031e7a861b052e39"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm", "00e3ebdc821fb3a36957320d49e8f4bfa310d73ea31c90e5f925dc75e030da8f"},
 }


### PR DESCRIPTION
Main aim of this PR is to enable automatic installation and setup in elixir and phoenix projects to lower adoption barrier.
The changes aim to

1. generate elixir bom
2. Generate npm bom
3. Merge the two boms
4. convert them to different formats (json, spdx etc)

4 above requires us to have the cyclonedx cli so we automatically check your system and install it which is also included.